### PR TITLE
Clear inspector when no multipart request/response is selected

### DIFF
--- a/src/extension/MimeInspector/Compression/GZipCompressor.cs
+++ b/src/extension/MimeInspector/Compression/GZipCompressor.cs
@@ -56,8 +56,7 @@ namespace MimeInspector.Compression
         /// Compresses the specified original stream.
         /// </summary>
         /// <param name="inputStream">The original stream.</param>
-        /// <param name="outputStream">The stream containing the zipped contents.</param>
-        /// <returns></returns>
+        /// <returns>A new Stream containing the compressed contents.</returns>
         public static Stream Compress(Stream inputStream)
         {
             var outputStream = new MemoryStream();

--- a/src/extension/MimeInspector/MimeRequestViewer.cs
+++ b/src/extension/MimeInspector/MimeRequestViewer.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Fiddler;
+using MimeInspector.Utilities;
 
 namespace MimeInspector
 {
     public class MimeRequestViewer : Inspector2, IRequestInspector2
     {
         private MimeView _mimeView;
-        private HTTPRequestHeaders _headers;
 
         public bool bDirty => false;
 
@@ -22,14 +24,25 @@ namespace MimeInspector
             {
                 if (value != null && value.Length > 0)
                 {
-                    try
+                    var mimeMessage = AsyncMimeParser.ParseMessage(value, headers, CancellationToken.None);
+
+                    if (mimeMessage != null)
                     {
-                        _mimeView.LoadBody(value, _headers);
+                        _mimeView.LoadMimeMessage(mimeMessage);                        
                     }
-                    catch (Exception)
+                    else
                     {
                         Clear();
                     }
+
+                    ////try
+                    ////{
+                    ////    _mimeView.LoadBody(value, _headers);
+                    ////}
+                    ////catch (Exception)
+                    ////{
+                    ////    Clear();
+                    ////}
                 }
                 else
                 {
@@ -44,34 +57,21 @@ namespace MimeInspector
             {
                 return true;
             }
-
             set
             {
             }
         }
 
-        public HTTPRequestHeaders headers
-        {
-            get
-            {
-                return null;
-            }
-
-            set
-            {
-                _headers = value;
-            }
-        }
+        public HTTPRequestHeaders headers { get; set; }
 
         public MimeRequestViewer()
         {
             _mimeView = new MimeView();
         }
 
-
         public void Clear()
         {
-            // TODO: Clear view
+            _mimeView.Clear();            
         }
 
         public override void AddToTab(TabPage o)

--- a/src/extension/MimeInspector/MimeRequestViewer.cs
+++ b/src/extension/MimeInspector/MimeRequestViewer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading;
 using System.Windows.Forms;
 using Fiddler;
 using MimeInspector.Utilities;
@@ -9,7 +7,7 @@ namespace MimeInspector
 {
     public class MimeRequestViewer : Inspector2, IRequestInspector2
     {
-        private MimeView _mimeView;
+        private readonly MimeView _mimeView;
 
         public bool bDirty => false;
 
@@ -34,15 +32,6 @@ namespace MimeInspector
                     {
                         Clear();
                     }
-
-                    ////try
-                    ////{
-                    ////    _mimeView.LoadBody(value, _headers);
-                    ////}
-                    ////catch (Exception)
-                    ////{
-                    ////    Clear();
-                    ////}
                 }
                 else
                 {
@@ -76,7 +65,6 @@ namespace MimeInspector
 
         public override void AddToTab(TabPage o)
         {
-            _mimeView = new MimeView();
             o.Text = "MIME";
             o.Controls.Add(_mimeView);
             _mimeView.Dock = DockStyle.Fill;

--- a/src/extension/MimeInspector/MimeResponseViewer.cs
+++ b/src/extension/MimeInspector/MimeResponseViewer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Threading;
 using System.Windows.Forms;
 using Fiddler;
+using MimeInspector.Utilities;
 
 namespace MimeInspector
 {
@@ -22,14 +24,25 @@ namespace MimeInspector
             {
                 if (value != null && value.Length > 0)
                 {
-                    try
+                    var mimeMessage = AsyncMimeParser.ParseMessage(value, headers, CancellationToken.None);
+
+                    if (mimeMessage != null)
                     {
-                        _mimeView.LoadBody(value, _headers);
+                        _mimeView.LoadMimeMessage(mimeMessage);
                     }
-                    catch (Exception)
+                    else
                     {
                         Clear();
                     }
+
+                    ////try
+                    ////{
+                    ////    _mimeView.LoadBody(value, _headers);
+                    ////}
+                    ////catch (Exception)
+                    ////{
+                    ////    Clear();
+                    ////}
                 }
                 else
                 {

--- a/src/extension/MimeInspector/MimeResponseViewer.cs
+++ b/src/extension/MimeInspector/MimeResponseViewer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Windows.Forms;
 using Fiddler;
 using MimeInspector.Utilities;
@@ -8,8 +7,7 @@ namespace MimeInspector
 {
     public class MimeResponseViewer : Inspector2, IResponseInspector2
     {
-        private MimeView _mimeView;
-        private HTTPResponseHeaders _headers;
+        private readonly MimeView _mimeView;
 
         public bool bDirty => false;
 
@@ -34,15 +32,6 @@ namespace MimeInspector
                     {
                         Clear();
                     }
-
-                    ////try
-                    ////{
-                    ////    _mimeView.LoadBody(value, _headers);
-                    ////}
-                    ////catch (Exception)
-                    ////{
-                    ////    Clear();
-                    ////}
                 }
                 else
                 {
@@ -63,18 +52,7 @@ namespace MimeInspector
             }
         }
 
-        public HTTPResponseHeaders headers
-        {
-            get
-            {
-                return null;
-            }
-
-            set
-            {
-                _headers = value;
-            }
-        }
+        public HTTPResponseHeaders headers { get; set; }
 
         public MimeResponseViewer()
         {
@@ -83,7 +61,6 @@ namespace MimeInspector
 
         public override void AddToTab(TabPage o)
         {
-            _mimeView = new MimeView();
             o.Text = "MIME";
             o.Controls.Add(_mimeView);
             _mimeView.Dock = DockStyle.Fill;
@@ -91,6 +68,7 @@ namespace MimeInspector
 
         public void Clear()
         {
+            _mimeView.Clear();
         }
 
         public override int GetOrder()

--- a/src/extension/MimeInspector/MimeView.cs
+++ b/src/extension/MimeInspector/MimeView.cs
@@ -83,8 +83,7 @@ namespace MimeInspector
                         {
                             using (FileStream fs = new FileStream(dialog.FileName, FileMode.OpenOrCreate))
                             {
-                                MimePart part = ((MenuItem)s).Tag as MimePart;
-                                if (part != null)
+                                if( ((MenuItem)s).Tag is MimePart part )                                
                                 {
                                     part.ContentObject.WriteTo(fs);
                                 }

--- a/src/extension/MimeInspector/MimeView.cs
+++ b/src/extension/MimeInspector/MimeView.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using Fiddler;
 using MimeInspector.Compression;
@@ -94,10 +92,19 @@ namespace MimeInspector
                             {
                                 Process.Start(dialog.FileName);
                             }
-
                         }
                     };
                 }
+
+                if (messageTree.Nodes.Count > 0)
+                {
+                    var firstNode = messageTree.Nodes[0];
+                    firstNode.Expand();
+
+                    messageTree.SelectedNode = firstNode;
+                    firstNode.EnsureVisible();
+                }
+
             }
             finally
             {

--- a/src/extension/MimeInspector/MimeView.cs
+++ b/src/extension/MimeInspector/MimeView.cs
@@ -113,7 +113,7 @@ namespace MimeInspector
                 {
                     stream = GZipCompressor.Decompress(stream);
                 }
-                body = ReadFully(stream);
+                body = StreamUtilities.ReadFully(stream);
 
             }
 
@@ -131,18 +131,6 @@ namespace MimeInspector
             _xmlRequest.body = body;
         }
 
-        public static byte[] ReadFully(Stream input)
-        {
-            byte[] buffer = new byte[16 * 1024];
-            using (MemoryStream ms = new MemoryStream())
-            {
-                int read;
-                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    ms.Write(buffer, 0, read);
-                }
-                return ms.ToArray();
-            }
-        }
+       
     }
 }

--- a/src/extension/MimeInspector/Utilities/AsyncMimeParser.cs
+++ b/src/extension/MimeInspector/Utilities/AsyncMimeParser.cs
@@ -1,29 +1,59 @@
 ﻿using MimeKit;
 using System;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Fiddler;
+using MimeKit.IO;
 
 namespace MimeInspector.Utilities
 {
     public static class AsyncMimeParser
     {
-        public static Task<MimeMessage> ParseMessageAsync(Stream inputStream, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<MimeMessage> ParseMessageAsync(byte[] message, HTTPHeaders headers, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (inputStream == null)
-            {
-                throw new ArgumentNullException(nameof(inputStream));
-            }
-
             return Task.Run(() =>
             {
-                MimeMessage parsedMessage = null;
-
-                var parser = new MimeParser(inputStream);
-                parsedMessage = parser.ParseMessage(cancellationToken);
-
-                return parsedMessage;
+                return ParseMessage(message, headers, cancellationToken);
             }, cancellationToken);
+        }
+
+        public static Task<MimeMessage> ParseMessageAsync(Stream inputStream, HTTPHeaders headers, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.Run(() =>
+            {
+                return ParseMessage(inputStream, headers, cancellationToken);
+            }, cancellationToken);
+        }
+
+        public static MimeMessage ParseMessage(byte[] message, HTTPHeaders headers, CancellationToken cancellationToken)
+        {
+            using (var ms = new MemoryStream(message))
+            {
+                return ParseMessage(ms, headers, cancellationToken);
+            }
+        }
+
+        public static MimeMessage ParseMessage(Stream inputStream, HTTPHeaders headers, CancellationToken cancellationToken)
+        {
+            if (inputStream == null || inputStream == Stream.Null)
+            {
+                return null;
+            }
+
+            string headerString = String.Join("\r\n", headers.ToArray().Select(h => $"{h.Name}:{h.Value}"));
+
+            using (ChainedStream streamWithHeaders = new ChainedStream())
+            {
+                streamWithHeaders.Add(new MemoryStream(Encoding.UTF8.GetBytes(headerString)), false);
+                streamWithHeaders.Add(inputStream, false);
+
+                var parser = new MimeParser(streamWithHeaders);
+
+                return parser.ParseMessage(cancellationToken);
+            }
         }
     }
 }

--- a/src/extension/MimeInspector/Utilities/StreamUtilities.cs
+++ b/src/extension/MimeInspector/Utilities/StreamUtilities.cs
@@ -28,24 +28,5 @@ namespace MimeInspector.Utilities
             }
         }
 
-        public static Stream CreateStreamFromBodyAndHttpHeaders(byte[] body, HTTPHeaders headers)
-        {
-            if (body == null)
-            {
-                throw new ArgumentNullException(nameof(body));
-            }
-            if (headers == null)
-            {
-                throw new ArgumentNullException(nameof(headers));
-            }
-
-            ChainedStream resultStream = new ChainedStream();
-
-            string headerString = string.Join("\r\n", headers.ToArray().Select(x => $"{x.Name}: {x.Value}"));
-            resultStream.Add(new MemoryStream(Encoding.UTF8.GetBytes(headerString)));
-            resultStream.Add(new MemoryStream(body));
-
-            return resultStream;
-        }
     }
 }

--- a/src/extension/MimeInspector/Utilities/StreamUtilities.cs
+++ b/src/extension/MimeInspector/Utilities/StreamUtilities.cs
@@ -9,6 +9,25 @@ namespace MimeInspector.Utilities
 {
     internal class StreamUtilities
     {
+        /// <summary>
+        /// Reads the <paramref name="input"/> Stream and return its contents as a byte array.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static byte[] ReadFully(Stream input)
+        {
+            byte[] buffer = new byte[16 * 1024];
+            using (MemoryStream ms = new MemoryStream())
+            {
+                int read;
+                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                }
+                return ms.ToArray();
+            }
+        }
+
         public static Stream CreateStreamFromBodyAndHttpHeaders(byte[] body, HTTPHeaders headers)
         {
             if (body == null)

--- a/src/extension/MimeInspector/project.json
+++ b/src/extension/MimeInspector/project.json
@@ -1,13 +1,12 @@
 ﻿{
   "dependencies": {
-    "MimeKit": "1.2.20.2"
-
+    "MimeKit": "1.18.1"
   },
-
   "frameworks": {
-    "net461": {
-    }
+    "net461": {}
   },
-  "supports": { },
-  "runtimes": {"win": {}}
+  "supports": {},
+  "runtimes": {
+    "win": {}
+  }
 }


### PR DESCRIPTION
- MIME parts are now properly shown in Inspector (previously only the raw contents were displayed, I presume the code in the repository was not up-to-date with the working version of MIME-inspector ?)

- When a request/response is selected in Fiddler that does not contain a multipart content, and the MIME inspector is active, the inspector window is cleared.

- Some code refactorings